### PR TITLE
Completed separating sparse-dot-mkl warnings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyo
+*.pyc
+/**/__pycache/

--- a/modules/TensorFox/Compression.py
+++ b/modules/TensorFox/Compression.py
@@ -233,7 +233,7 @@ def sparse_dot_mkl_call(Tl, mkl_dot):
         os.environ["MKL_INTERFACE_LAYER"] = "ILP64"
         from sparse_dot_mkl import dot_product_mkl
     except:
-        print('        Module sparse_dot_mkl could not be imported. Using standard scipy dot.')
+        print('\tModule sparse_dot_mkl could not be imported. Using standard scipy dot.', file=sys.sdterr)
         mkl_dot = False
         
     if mkl_dot:
@@ -241,10 +241,10 @@ def sparse_dot_mkl_call(Tl, mkl_dot):
             TlT = Tl.T
             Tl = dot_product_mkl(Tl, TlT, copy=False, dense=True)
         except Exception as e:
-            print('        ' + str(e) + '. Using standard scipy dot.')
+            print('\t' + str(e) + '. Using standard scipy dot.', file=sys.stderr)
             Tl = sparse_dot_calls(Tl)
     else:
-        print('        Matrix is too large for sparse_dot_mkl. Using standard scipy dot.')
+        print('\tMatrix is too large for sparse_dot_mkl. Using standard scipy dot.', file=sys.stderr)
         Tl = sparse_dot_calls(Tl)
         
     return Tl
@@ -331,7 +331,7 @@ def safe_sparse_dot(a, b, mkl_dot):
         try:
             from sparse_dot_mkl import dot_product_mkl
         except:
-            print('Module sparse_dot_mkl could not be imported. Using standard scipy dot function instead.')
+            print('Module sparse_dot_mkl could not be imported. Using standard scipy dot function instead.', file=sys.stderr)
             mkl_dot = False
         if mkl_dot:
             if (sparse.issparse(a) and a.getformat() == 'csr') or (sparse.issparse(b) and b.getformat() == 'csr'):

--- a/modules/TensorFox/__init__.py
+++ b/modules/TensorFox/__init__.py
@@ -1,2 +1,6 @@
 # __init__.py
+__version__ = '1.0.1'
+def version():
+    return (1, 0, 1)
+
 from .TensorFox import *

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ setup(
     name='TensorFox',
     version='1.0.1',
     description='Python3 package for Multilinear Algebra and Tensor routines.',
-    long_description=long_description
-    long_description_content_type='text/markdown'
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     license='GNU',
     author="Felipe Bottega Diniz",
     author_email='felipebottega@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,24 @@
 from setuptools import setup, find_packages
+import pathlib
 
+# import pdb; pdb.set_trace()
+# learned from https://github.com/pypa/sampleproject/
+here = pathlib.Path(__file__).parent.resolve()
+long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='TensorFox',
-    version='1.0',
+    version='1.0.1',
+    description='Python3 package for Multilinear Algebra and Tensor routines.',
+    long_description=long_description
+    long_description_content_type='text/markdown'
     license='GNU',
     author="Felipe Bottega Diniz",
     author_email='felipebottega@gmail.com',
     packages=find_packages('modules'),
     package_dir={'': 'modules'},
     url='https://github.com/felipebottega/Tensor-Fox',
-    keywords='Tensor Fox',
+    keywords='Tensor Fox, CPD, PARAFAC, CANDECOMP',
     install_requires=[
           'numpy',
           'pandas',
@@ -18,7 +26,8 @@ setup(
           'sklearn',
           'matplotlib',
           'numba',
-          'sparse_dot_mkl',
+          'IPython',
+          'sparse_dot_mkl>=0.7,<0.8',
       ],
 
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages('modules'),
     package_dir={'': 'modules'},
     url='https://github.com/felipebottega/Tensor-Fox',
-    keywords='Tensor Fox, CPD, PARAFAC, CANDECOMP',
+    keywords='Tensor Fox CPD PARAFAC CANDECOMP',
     install_requires=[
           'numpy',
           'pandas',


### PR DESCRIPTION
Warnings about sparse-dot-mkl are now redirected to sys.stderr (standard error file stream).

If the user on command line invokes:
C:\example\folder> python 2>error.txt
All sparse-dot-mkl replaced by scipy warning messages goes to this error.txt file.

However if the user invokes:
C:\example\folder> python
They still appear normally in the command prompt as in interactive mode.